### PR TITLE
Add do_warmup config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ The layout of each configuration file is as follows:
   "pin_cpus": <Boolean. Optional, defaults to false. If true, attempt to pin
     benchmarks to CPU cores, evenly distributed across cores. If true,
     individual benchmark cpu_core settings are ignored.>,
+  "do_warmup": <Boolean. Optional, defaults to false. If true, runs each
+    benchmark for a small, arbitrary, number of iterations after initializing
+    but before starting to take measurements.>,
   "sync_every_iteration": <Boolean. Optional, defaults to false. If true,
     iterations of each benchmark start when all benchmarks have completed their
     previous iteration. By default, each benchmark only waits for its own

--- a/src/parse_config.c
+++ b/src/parse_config.c
@@ -56,6 +56,7 @@ static int VerifyGlobalConfigKeys(cJSON *main_config) {
     "cuda_device",
     "base_result_directory",
     "pin_cpus",
+    "do_warmup",
     "benchmarks",
     "comment",
     "sync_every_iteration",
@@ -386,6 +387,18 @@ GlobalConfiguration* ParseConfiguration(const char *config) {
     to_return->sync_every_iteration = tmp == cJSON_True;
   } else {
     to_return->sync_every_iteration = 0;
+  }
+  // The do_warmup setting defaults to 0.
+  entry = cJSON_GetObjectItem(root, "do_warmup");
+  if (entry) {
+    tmp = entry->type;
+    if ((tmp != cJSON_True) && (tmp != cJSON_False)) {
+      printf("Invalid do_warmup setting in config.\n");
+      goto ErrorCleanup;
+    }
+    to_return->do_warmup = tmp == cJSON_True;
+  } else {
+    to_return->do_warmup = 0;
   }
   // Finally, parse the benchmark list. Ensure that we've obtained a valid JSON
   // array for the benchmarks before calling ParseBenchmarkList.

--- a/src/parse_config.h
+++ b/src/parse_config.h
@@ -70,6 +70,10 @@ typedef struct {
   // benchmark's cpu_core setting. If nonzero, benchmarks are distributed
   // evenly accrorss CPU cores.
   int pin_cpus;
+  // If nonzero, run each benchmark for one or more iterations without
+  // recording performance after initialization, but before syncing with other
+  // plugins and starting to take measurements.
+  int do_warmup;
   // If zero, iterations of individual benchmarks run as soon as previous
   // iterations complete. If 1, then every benchmark starts each iteration
   // only after the previous iteration of every benchmark has completed.


### PR DESCRIPTION
 - Added a boolean "do_warmup" option to top-level configs. If provided
   and set to true, this will cause each benchmark to run a few
   iterations prior to measurements being taken.