### PR TITLE
Improve release marker stacking logic in view_blocksbysm.py

### DIFF
--- a/scripts/view_blocksbysm.py
+++ b/scripts/view_blocksbysm.py
@@ -974,8 +974,10 @@ class BlockSMDisplay():
             else:
                 pass # invalid!
 
-        # Draw a marker for the kernel release time
-        releaseBucket = int(kernel.releaseTime / 0.02)
+        # Draw a marker arrow for the kernel release time
+        # (Stack markers if releases differ by less than ~1% of plot length)
+        epsilon = (self.totalTime / 100)
+        releaseBucket = int(kernel.releaseTime / epsilon)
         releaseIdx = releaseDict.get(releaseBucket, 0)
         releaseDict[releaseBucket] = releaseIdx + 1
         krm = KernelReleaseMarker(kernel, self.firstTime, self.totalTime,


### PR DESCRIPTION
Markers would previously be stacked if closer than 0.02 seconds apart, even if the entire plot covered only 0.02 seconds.

Change logic to only stack markers if they're close relative to the amount of time plotted. ~1% is a semi-arbitrary threshold that seems to look fine.