### PR TITLE
Support an arbitrary number of streams in `view_blocksbysm.py`

### DIFF
--- a/scripts/view_blocksbysm.py
+++ b/scripts/view_blocksbysm.py
@@ -589,7 +589,7 @@ class LegendBox(object):
         self.rect.setWidth(LINE_WIDTH)
 
         if USE_PATTERNS:
-            color = idToColorMap[i]
+            color = idToColorMap[i % len(idToColorMap)]
             self.rect.setFill(patternColorToBgColorMap[color])
 
             patternType = idToPatternMap[i % len(idToPatternMap)]
@@ -887,7 +887,7 @@ class BlockSMDisplay():
         smBase = [[] for j in range(self.numSms)]
         releaseDict = {}
         for i in range(len(self.benchmark.streams)):
-            color = idToColorMap[i] if USE_PATTERNS else patternColorToArrowColorMap[idToColorMap[i]]
+            color = idToColorMap[i % len(idToColorMap)] if USE_PATTERNS else patternColorToArrowColorMap[idToColorMap[i % len(idToColorMap)]]
             patternType = idToPatternMap[i % len(idToPatternMap)] if USE_PATTERNS else None
             self.draw_stream(self.benchmark.streams[i], color, patternType, i, smBase, releaseDict)
 

--- a/src/matrix_multiply.cu
+++ b/src/matrix_multiply.cu
@@ -67,6 +67,7 @@ static void Cleanup(void *data) {
   if (state->device_block_times) cudaFree(state->device_block_times);
   if (state->device_block_smids) cudaFree(state->device_block_smids);
 
+  // Clear memory so that use-after-free bugs are obvious
   memset(state, 0, sizeof(*state));
   free(state);
 }

--- a/src/task_host.c
+++ b/src/task_host.c
@@ -222,7 +222,7 @@ static int SetCPUAffinity(TaskConfig *config) {
 
 // Formats the given timing information as a JSON object and appends it to the
 // output file. Returns 0 on error and 1 on success. Times will be written in a
-// floatig-point number of *seconds*, even though they are recorded in ns. This
+// floating-point number of *seconds*, even though they are recorded in ns. This
 // code should not be included in benchmark timing measurements.
 static int WriteTimesToOutput(FILE *output, TimingInformation *times,
     SharedState *shared_state) {


### PR DESCRIPTION
Necessary for plots such as Fig. 12 in "Hardware Compute Partitioning on NVIDIA GPUs" by Bakita and Anderson at RTAS'23.

Previously only up to 25 streams could be plotted.

Also two comment fixes.